### PR TITLE
fix: prefer URL construction over string concat

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,3 @@
-// {
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pino-parseable",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "pino transport for parseable",
     "main": "dist/src/index.js",
     "author": "Battlesquid",

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ export const send = async (options: ParseableSendOptions) => {
         "Content-Type": "application/json"
     };
 
-    await fetch(`${endpoint}/api/v1/ingest`, {
+    await fetch(new URL("/api/v1/ingest", endpoint), {
         method: "POST",
         redirect: "follow",
         body,


### PR DESCRIPTION
Replaces string concatenation with URL construction. Basically, if the user defined an endpoint like `https://my-parseable-endpoint.com/` and used that in the transport options, the final endpoint url with the ingest endpoint appended would be `https://my-parseable-endpoint.com//api/v1/ingest`, which is invalid.